### PR TITLE
Don't append to existing binary when assembling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ val binaryJar = task("binaryJar") {
     val fatJarFile = fatJar.archiveFile.get().asFile
 
     binaryFile.parentFile.mkdirs()
-    binaryFile.appendText("#!/bin/sh\n\nexec java -jar \$0 \"\$@\"\n\n")
+    binaryFile.writeText("#!/bin/sh\n\nexec java -jar \$0 \"\$@\"\n\n")
     binaryFile.appendBytes(fatJarFile.readBytes())
 
     binaryFile.setExecutable(true)


### PR DESCRIPTION
If you keep building without cleaning the binary will keep growing. I just fixed protogram and percent.